### PR TITLE
Fix al::GetBaseName

### DIFF
--- a/Data/OK.json
+++ b/Data/OK.json
@@ -1,1 +1,1 @@
-{"label": "Matching", "message": "290", "color": "success", "schemaVersion": 1}
+{"label": "Matching", "message": "291", "color": "success", "schemaVersion": 1}

--- a/Source/al/Util/StringUtil.cpp
+++ b/Source/al/Util/StringUtil.cpp
@@ -4,8 +4,6 @@
 
 namespace al {
 
-NON_MATCHING
-// addne swapped
 const char* getBaseName(const char* name)
 {
     const char* baseName = std::strrchr(name, '/');

--- a/Source/al/Util/StringUtil.cpp
+++ b/Source/al/Util/StringUtil.cpp
@@ -9,7 +9,7 @@ NON_MATCHING
 const char* getBaseName(const char* name)
 {
     const char* baseName = std::strrchr(name, '/');
-    return baseName ? baseName + 1 : name;
+    return !baseName ? name : baseName + 1;
 }
 
 const char* createStringIfInStack(const char* str)

--- a/Symbols/al/Util/StringUtil.sym
+++ b/Symbols/al/Util/StringUtil.sym
@@ -1,3 +1,3 @@
-_ZN2al11getBaseNameEPKc,00272634,32,m
+_ZN2al11getBaseNameEPKc,00272634,32,O
 _ZN2al21createStringIfInStackEPKc,002504a8,76,O
 _ZN2al13isEqualStringEPKcS1_,00292308,56,O


### PR DESCRIPTION
Condition should be inverted to fix the assembly.
Relevant decomp.me: https://decomp.me/scratch/5m6Yo

Please squash the commits before merging.